### PR TITLE
0.1.4 Quest Book Updates

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -27454,7 +27454,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Glowing!\n\nThis one takes a significant amount of time to cook, so make sure to have it going constantly.\n\nWires made from §6Lumium§r transmit IV power losslessly, and it forms the basis for §6LuV Machine Hulls§r.",
+          "desc:8": "Glowing!\n\nThis one takes a significant amount of time to cook, so make sure to have it going constantly.\n\nCables made from §6Lumium§r transmit IV power losslessly, and it forms the basis for §6LuV Machine Hulls§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31525,7 +31525,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Coating §6Draconium Wire§r with §9Molten Nether Star§r and freezing it solid results in a superconductive material capable of transmitting enormous amounts of energy.\n\nThese wires losslessly transmit \"MAX\" tier, which is effectively infinite transfer rate. This means they will work for any tier of power. 1x wires handle 4 amps, meaning 4x wires can handle 16 amps.\n\nThese can also be made into RF conduits that can transmit a whopping 134 Million RF/t.",
+          "desc:8": "Coating §6Draconium Wire§r with §9Molten Nether Star§r and freezing it solid results in a superconductive material capable of transmitting enormous amounts of energy.\n\nThese cables losslessly transmit \"MAX\" tier, which is effectively infinite transfer rate. This means they will work for any tier of power. 1x wires handle 4 amps, meaning 4x wires can handle 16 amps.\n\nThese can also be made into RF conduits that can transmit a whopping 134 Million RF/t.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -40000,7 +40000,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need to get into cooking§6 Steel§r, which is going to be your main resource a bit later.  Don\u0027t get confused: both recipes aren\u0027t shown in §bJEI§r.\n\nTo get started, you\u0027ll need a decent amount of both clay and firebricks. In order to construct a §6Primitive Blast Furnace§r, you\u0027ll need §632 Primitive Bricks§r and a §6PBF Controller§r. \n\nYou can find the multiblock preview in JEI, and you can also sneak-right click the controller to enable the in-world preview.\n\nIt\u0027s not a bad idea to build several of these.",
+          "desc:8": "You\u0027ll need to get into cooking§6 Steel§r, which is going to be your main resource a bit later.  Don\u0027t get confused: both recipes aren\u0027t shown in §bJEI§r.\n\nTo get started, you\u0027ll need a decent amount of both clay and firebricks. In order to construct a §6Primitive Blast Furnace§r, you\u0027ll need §632 Primitive Bricks§r and a §6PBF Controller§r. \n\nYou can find the multiblock preview in JEI, and you can also sneak-right click the controller to enable the in-world preview.\n\nOnce the multiblock is built, right-click the Controller and insert a piece of either §6Iron§r or §6Wrought Iron§r alongside some Coal or Coal coke to begin cooking Steel. §aUsing Wrought Iron is better since it\u0027s 250% faster compared to regular Iron, so make sure to smelt your Iron beforehand.§r \n\nIt\u0027s not a bad idea to build several of these.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -26135,7 +26135,7 @@
     },
     "502:10": {
       "preRequisites:11": [
-        19,
+        787,
         52
       ],
       "properties:10": {
@@ -31047,7 +31047,7 @@
     },
     "599:10": {
       "preRequisites:11": [
-        19,
+        787,
         23
       ],
       "properties:10": {
@@ -37510,7 +37510,7 @@
     },
     "732:10": {
       "preRequisites:11": [
-        19
+        787
       ],
       "properties:10": {
         "betterquesting:10": {

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -13169,7 +13169,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Chaos Shards§r are an endgame component for §bDraconic Evolution§r.\n\nThey are the base material for Chaotic Tier materials and come exclusively from Tier Eight Micro Miners.\n\nTechnically they also come from Chaos Guardians, but in the quantities you\u0027ll need these? That would be a silly prospect.",
+          "desc:8": "§6Chaos Shards§r are an endgame component for §bDraconic Evolution§r.\n\nThey are the base material for Chaotic Tier materials and come exclusively from Tier Eight Micro Miners.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -31314,7 +31314,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "No hypothetical aliens were harmed in the harvesting of this item.\n\nProbably.\n\nMelting the heart of a universe provides a rather useful liquid: §dMolten Creative Portable Tank§r.",
+          "desc:8": "No hypothetical aliens were harmed in the harvesting of this item.\n\nProbably.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -41138,24 +41138,7 @@
         }
       },
       "questID:3": 803,
-      "rewards:9": {
-        "0:10": {
-          "index:3": 0,
-          "rewardID:8": "bq_standard:item",
-          "rewards:9": {
-            "0:10": {
-              "Count:3": 1,
-              "Damage:2": 0,
-              "OreDict:8": "",
-              "id:8": "betterquesting:placeholder",
-              "tag:10": {
-                "orig_id:8": "contenttweaker:omnicoin5",
-                "orig_meta:3": 0
-              }
-            }
-          }
-        }
-      },
+      "rewards:9": {},
       "tasks:9": {
         "0:10": {
           "autoConsume:1": 0,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -13117,7 +13117,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Eighth Micro Miner.\n\nThe main source of §6Chaos Shards§r: as with Nether Stars and Withers, farming these in the needed amounts from Chaos Guardians would be absurd.\n\nThe other mission gives negligible amounts of §6Neutronium§r and some other moderately useful things, but you\u0027re better off making Neutronium in the §3Fusion Reactor Mark 3§r§r and the other items are otherwise craftable.",
+          "desc:8": "The Eighth Micro Miner.\n\nThe main source of §6Chaos Shards§r.\n\nThe other mission gives negligible amounts of §6Neutronium§r and some other moderately useful things, but you\u0027re better off making Neutronium in the §3Fusion Reactor Mark 3§r§r and the other items are otherwise craftable.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -18189,7 +18189,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The highest tier of fusion crafting injectors. You will need at least ten of these to reach the §dCreative Portable Tank§r.\n\nEach injector requires four ingots of §6Neutronium§r and four §6Chaos Shards§r, as well as two §6Crystal Matrix§r blocks.\n\nHope you\u0027ve got those Tier Eight Micro Miners automated.",
+          "desc:8": "The highest tier of fusion crafting injectors. You will need at least ten of these to reach the §dHeart of a Universe§r.\n\nEach injector requires four ingots of §6Neutronium§r and four §6Chaos Shards§r, as well as two §6Crystal Matrix§r blocks.\n\nHope you\u0027ve got those Tier Eight Micro Miners automated.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -27955,7 +27955,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6ZPM Machine Hulls§r are made with §6Iridium Plates§r, but you\u0027ll notice they also need §9Polytetrafluoroethylene§r (more commonly known as Teflon™), a special plastic which will be required for all machine hulls going forward.\n\nZPM stands for Zero Point Module.\n\nThis is the last tier of machine that\u0027s sensible to produce before you reach the §dCreative Portable Tank§r. Multiblock hatches are a different matter- feel free to upgrade your §3EBF§rs to Ultimate Voltage, if you can handle the power drain. There\u0027s no usable tier above that, though.",
+          "desc:8": "§6ZPM Machine Hulls§r are made with §6Iridium Plates§r, but you\u0027ll notice they also need §9Polytetrafluoroethylene§r (more commonly known as Teflon™), a special plastic which will be required for all machine hulls going forward.\n\nZPM stands for Zero Point Module.\n\nThis is the last tier of machine that\u0027s sensible to produce before you reach the §dHeart of a Universe§r. Multiblock hatches are a different matter- feel free to upgrade your §3EBF§rs to Ultimate Voltage, if you can handle the power drain. There\u0027s no usable tier above that, though.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -36135,7 +36135,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Naquadah Reactor Mk2§r is an upgraded reactor that can generate immense amounts of EU energy from the same types of fuels as the Mk1. The materials it requires are similar to the Mk1, and you can almost reuse the same structure. Make sure you are prepared for the UV power output by adding a §6UV Energy Output Hatch§r.\n\nThis is a pretty expensive structure though, as it needs blocks of §dOmnium§r. Maybe wait until after you get the §dCreative Portable Tank§r?\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "The §3Naquadah Reactor Mk2§r is an upgraded reactor that can generate immense amounts of EU energy from the same types of fuels as the Mk1. The materials it requires are similar to the Mk1, and you can almost reuse the same structure. Make sure you are prepared for the UV power output by adding a §6UV Energy Output Hatch§r.\n\nThis is a pretty expensive structure though, as it needs blocks of §dOmnium§r.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -40889,7 +40889,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have §6Awakened Cores§r, you can make the §eEnergy Storage Core§r from §bDraconic Evolution§r. It\u0027s a great way to store all the energy required to craft power-hungry late game items.\n\nThe §eEnergy Storage Core§r is a multiblock structure that can be upgraded to store increasingly immense amounts of RF energy. See the §bDraconic Evolution§r manual for more information on the material requirements for each tier.\n\n§6Energy Pylons§r are required to input and output energy from the core. Each pylon allows movement in a single direction, so you need at least two.\n\nOnce you have the materials together for your desired tier, § the structure can build itself: simply access the GUI of the §6Energy Core§r, set the tier, and click Assemble. Items will be automatically used from your inventory. Once the structure is built, you can access the core\u0027s GUI again through §6Energy Core Stabilizers§r to activate it.\n\nIt is recommended to postpone Tier 8 until after you reach the §dCreative Portable Tank§r, as it requires large amounts of §6Awakened Draconium§r.\n\n",
+          "desc:8": "Now that you have §6Awakened Cores§r, you can make the §eEnergy Storage Core§r from §bDraconic Evolution§r. It\u0027s a great way to store all the energy required to craft power-hungry late game items.\n\nThe §eEnergy Storage Core§r is a multiblock structure that can be upgraded to store increasingly immense amounts of RF energy. See the §bDraconic Evolution§r manual for more information on the material requirements for each tier.\n\n§6Energy Pylons§r are required to input and output energy from the core. Each pylon allows movement in a single direction, so you need at least two.\n\nOnce you have the materials together for your desired tier, § the structure can build itself: simply access the GUI of the §6Energy Core§r, set the tier, and click Assemble. Items will be automatically used from your inventory. Once the structure is built, you can access the core\u0027s GUI again through §6Energy Core Stabilizers§r to activate.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -5227,7 +5227,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Sulfuric Acid§r is produced from §6Sulfur§r and §9Water§r. You\u0027ll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.\n\nSulfur can be electrolyzed from many things, but is also easily available via §bDeepMobLearning§r\u0027s §aBlaze Model§r.",
+          "desc:8": "§9Sulfuric Acid§r is produced from §6Sulfur§r and §9Water§r. You\u0027ll need huge amounts of this for a whole range of chemical reactions, as it is a very common ingredient.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8907,7 +8907,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A whole host of fluids can be used as the feedstock for your §9Bio Diesel§r, including §9Seed Oil§r, §9Fish Oil§r, and the various tiers of §9Canola Oils§r.\n\nFish Oil and Canola Oil are probably the easiest, but it\u0027s up to you to choose.\n\nFish are easiest to get from §aGuardian Models§r from §bDML§r.",
+          "desc:8": "A whole host of fluids can be used as the feedstock for your §9Bio Diesel§r, including §9Seed Oil§r, §9Fish Oil§r, and the various tiers of §9Canola Oils§r.\n\nCanola Oil is probably the easiest, but it\u0027s up to you to choose.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -28104,7 +28104,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "These two dusts will be used in a variety of upcoming chemical reactions.\n\n§6Phosphorous§r can be obtained by processing §6Phosphor Ore§r into dust and electrolyzing several times. This ore is found in §6Apatite§r veins.\n\n§6Sulfur§r can be electrolyzed easily from §6Sphalerite§r (which also provides §6Gallium§r), §6Cinnabar§r, and §6Pyrite§r. Alternately, Sulfur can be acquired through §bDeep Mob Learning§r- look into that quest line if you haven\u0027t already.",
+          "desc:8": "These two dusts will be used in a variety of upcoming chemical reactions.\n\n§6Phosphorous§r can be obtained by processing §6Phosphor Ore§r into dust and electrolyzing several times. This ore is found in §6Apatite§r veins.\n\n§6Sulfur§r can be electrolyzed easily from §6Sphalerite§r (which also provides §6Gallium§r), §6Cinnabar§r, and §6Pyrite§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -37567,7 +37567,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aDraconic Evolution Information Tablet§r contains useful information about the mod as well as diagrams for valid Fusion Crafting block placement.\n\nYou might also be interested in the §oDraconic Evolution Fusion Core Automation§r guide linked to in §9#omnicompendium§r in the official §5Omnifactory: Self-Torture Edition§f Discord server.",
+          "desc:8": "The §aDraconic Evolution Information Tablet§r contains useful information about the mod as well as diagrams for valid Fusion Crafting block placement.\n\nYou might also be interested in the §oDraconic Evolution Fusion Core Automation§r guide linked to in §9#omnicompendium§r in the official §5Omnifactory Discord server§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -15420,7 +15420,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Man, that\u0027s a LOT of quests linked to this one.\n\n§dOmnium§r, as the name suggests, is an incredible material composed of all elements and alloys you\u0027ve encountered so far.\n\nFun fact: you\u0027ll need to make 487 motes. You\u0027ve got all this automated, right?",
+          "desc:8": "Man, that\u0027s a LOT of quests linked to this one.\n\n§dOmnium§r, as the name suggests, is an incredible material composed of all elements and alloys you\u0027ve encountered so far.\n\nYou will be making a lot of these. Make sure to set up proper automation for each element mentioned below.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -13747,9 +13747,9 @@
             },
             "3:10": {
               "Count:3": 15,
-              "Damage:2": 10,
+              "Damage:2": 8,
               "OreDict:8": "",
-              "id:8": "gregtech:compressed_3"
+              "id:8": "gregtech:meta_block_compressed_4"
             },
             "4:10": {
               "Count:3": 2,
@@ -19211,9 +19211,9 @@
             },
             "4:10": {
               "Count:3": 4,
-              "Damage:2": 5,
+              "Damage:2": 12,
               "OreDict:8": "",
-              "id:8": "gregtech:compressed_9"
+              "id:8": "gregtech:meta_block_compressed_12"
             },
             "5:10": {
               "Count:3": 54,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -40115,18 +40115,18 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Compressor§r is a machine that compresses things into denser things. In particular, you\u0027ll need it for compressing §6Fireclay Dust§r into §6Compressed Fireclay§r.\n\nThis machine is capable of processing all recipes listed as §a32 EU/t and less§r in §bJEI§r.",
+          "desc:8": "§6Forge Hammer§r is a machine that\u0027s useful for compressing things into denser things... in a rather inefficient manner. In particular, you\u0027ll need it for compressing §6Fireclay Dust§r into §6Compressed Fireclay§r and §6Raw Rubber§r into §6Rubber Sheets§r.\n\nThis machine is capable of processing all recipes listed as §a32 EU/t and less§r in §bJEI§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
-            "Damage:2": 11,
+            "Damage:2": 13,
             "OreDict:8": "",
             "id:8": "gregtech:machine"
           },
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Compressor",
+          "name:8": "Forge Hammer",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -40151,7 +40151,7 @@
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
-              "Damage:2": 11,
+              "Damage:2": 13,
               "OreDict:8": "",
               "id:8": "gregtech:machine"
             }

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -25433,7 +25433,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A variant of §6Alloy Smelter§r that requires power instead of steam.",
+          "desc:8": "§3Compressor§r is an indirect upgrade to §3Forge Hammer§r; this machine doesn\u0027t suffer from inefficient recipes and allows you to turn ingots to plates in the 1:1 ratio.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25444,7 +25444,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "Powered Compressor",
+          "name:8": "LV Compressor",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -21180,7 +21180,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "ASSEMBLE... TOO!\n\nYeah you get to craft §6Nether Stars§r. Cool huh?\n\nOver the course of the pack, Nether Stars are going to be needed in quantities that far exceed a reasonable player\u0027s ability to farm Withers. §eCraft them, don\u0027t bother trying to farm them.",
+          "desc:8": "ASSEMBLE... TOO!\n\nYeah you get to craft §6Nether Stars§r. Cool huh?\n\nOver the course of the pack, Nether Stars are going to be needed in quantities that far exceed a reasonable player\u0027s ability to farm Withers. Which is, of course, impossible in this modpack.\n\nLater, you\u0027ll unlock the §6Tier Four and Half Micro Miner§r, which is undoubtedly the most efficient source of Nether Stars.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,


### PR DESCRIPTION
Closes #64 by fixing all mentioned inconsistencies.
Closes #59.

Additionally:
* Replaces "Compressor" with "Forge Hammer" since Steam Compressors are gone
* Adds a tip to "Primitive Blast Furnace" about Wrought Iron being better
* Properly gates several quests behind "Alloy Smelter" instead of "Powered Alloy Smelter"