### PR TITLE
Add a late game recipe for clay

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -963,3 +963,6 @@ makeShaped("me_controller", <appliedenergistics2:controller>,
 // i heard you like duping chlorine
 electrolyzer.findRecipe(60, [<ore:dustPolyvinylChloride>.firstItem * 6], [null]).remove();
 electrolyzer.findRecipe(60, [<ore:dustPolytetrafluoroethylene>.firstItem * 6], [null]).remove();
+
+// late game clay automation
+reactor.recipeBuilder().inputs([<contenttweaker:block_dust>]).fluidInputs([<liquid:water> * 1000]).outputs(<minecraft:clay>).EUt(131072).duration(20).buildAndRegister();


### PR DESCRIPTION
i added a late game recipe for clay like the one in normal Omnifactory, but at zpm level so Reyas#8293 on discord could automate vending.

I don't know zenscript, so i put it in the Earlygame.zs, where i copied it from